### PR TITLE
Merge `katana` integration changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3345,7 +3351,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4232,7 +4238,7 @@ dependencies = [
  "starknet-accounts",
  "starknet-contract",
  "starknet-core 0.11.1",
- "starknet-crypto 0.7.2",
+ "starknet-crypto 0.7.3",
  "starknet-macros",
  "starknet-providers",
  "starknet-signers",
@@ -4247,7 +4253,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "starknet-core 0.11.1",
- "starknet-crypto 0.7.2",
+ "starknet-crypto 0.7.3",
  "starknet-providers",
  "starknet-signers",
  "thiserror",
@@ -4283,7 +4289,7 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with 2.3.3",
  "sha3",
- "starknet-crypto 0.7.2",
+ "starknet-crypto 0.7.3",
  "starknet-types-core",
 ]
 
@@ -4302,7 +4308,7 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with 3.11.0",
  "sha3",
- "starknet-crypto 0.7.2",
+ "starknet-crypto 0.7.3",
  "starknet-types-core",
 ]
 
@@ -4348,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a5064173a8e8d2675e67744fd07f310de44573924b6b7af225a6bdd8102913"
+checksum = "ded22ccf4cb9e572ce3f77de6066af53560cd2520d508876c83bb1e6b29d5cbc"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -4488,9 +4494,10 @@ dependencies = [
  "serde_with 3.11.0",
  "serde_yaml",
  "sha2",
- "starknet-crypto 0.6.2",
+ "starknet-crypto 0.7.3",
  "starknet-gateway-types",
  "starknet-os-types",
+ "starknet-types-core",
  "starknet_api",
  "thiserror",
  "tokio",
@@ -4513,7 +4520,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.11.0",
  "starknet-core 0.11.1",
- "starknet-crypto 0.6.2",
+ "starknet-crypto 0.7.3",
  "starknet-gateway-types",
  "starknet-types-core",
  "starknet_api",
@@ -4555,7 +4562,7 @@ dependencies = [
  "getrandom",
  "rand",
  "starknet-core 0.11.1",
- "starknet-crypto 0.7.2",
+ "starknet-crypto 0.7.3",
  "thiserror",
 ]
 
@@ -4565,6 +4572,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa1b9e01ccb217ab6d475c5cda05dbb22c30029f7bb52b192a010a00d77a3d74"
 dependencies = [
+ "arbitrary",
  "lambdaworks-crypto",
  "lambdaworks-math",
  "lazy_static",
@@ -4794,7 +4802,7 @@ dependencies = [
  "rand",
  "rstest 0.18.2",
  "serde_json",
- "starknet-crypto 0.6.2",
+ "starknet-crypto 0.7.3",
  "starknet-os",
  "starknet-os-types",
  "starknet_api",
@@ -5329,7 +5337,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3612,6 +3612,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet",
+ "starknet-crypto 0.7.3",
  "starknet-os",
  "starknet-types-core",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,10 @@ sha2 = "0.10.8"
 starknet = "0.11.0"
 starknet_api = { git = "https://github.com/Moonsong-Labs/sequencer", rev = "6624e910c57db9a16f1607c1ed26f7d8f1114e73", features = ["testing"] }
 starknet-core = "0.11.1"
-starknet-crypto = "0.6.2"
+starknet-crypto = "0.7.3"
 starknet-os = { path = "crates/starknet-os" }
 starknet-os-types = { path = "crates/starknet-os-types" }
-starknet-types-core = "0.1.5"
+starknet-types-core = { version = "0.1.7", features = ["arbitrary", "hash"] }
 thiserror = "1.0.48"
 tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
 uuid = { version = "1.4.0", features = ["v4", "serde"] }

--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -295,26 +295,23 @@ pub async fn prove_block(
         })
         .collect();
 
-    // We can extract data from any storage proof, use the one of the block hash contract
-    let block_hash_storage_proof =
-        storage_proofs.get(&Felt::ONE).expect("there should be a storage proof for the block hash contract");
-    let previous_block_hash_storage_proof = previous_storage_proofs
-        .get(&Felt::ONE)
-        .expect("there should be a previous storage proof for the block hash contract");
+    // we're assuming there's always at least one storage proof in the list
+    let (.., prev_proofs) = previous_storage_proofs.iter().next().expect("there should be at least one storage proof");
+    let (.., new_proofs) = storage_proofs.iter().next().expect("there should be at least one storage proof");
 
     // The root of the class commitment tree for previous and current block
     // Using requested storage proof instead of getting them from class proofs
     // If the block doesn't contain transactions, `class_proofs` will be empty
     // Pathfinder will send a None on class_commitment when the tree is not initialized, ie, root is zero
-    let updated_root = block_hash_storage_proof.class_commitment.unwrap_or(Felt::ZERO);
-    let previous_root = previous_block_hash_storage_proof.class_commitment.unwrap_or(Felt::ZERO);
+    let previous_root = prev_proofs.class_commitment.unwrap_or(Felt::ZERO);
+    let updated_root = new_proofs.class_commitment.unwrap_or(Felt::ZERO);
 
     // On devnet and until block 10, the storage_root_idx might be None and that means that contract_proof is empty
-    let previous_contract_trie_root = match previous_block_hash_storage_proof.contract_proof.first() {
+    let previous_contract_trie_root = match prev_proofs.contract_proof.first() {
         Some(proof) => proof.hash::<PedersenHash>(),
         None => Felt252::ZERO,
     };
-    let current_contract_trie_root = match block_hash_storage_proof.contract_proof.first() {
+    let current_contract_trie_root = match new_proofs.contract_proof.first() {
         Some(proof) => proof.hash::<PedersenHash>(),
         None => Felt252::ZERO,
     };

--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -8,7 +8,7 @@ use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use cairo_vm::Felt252;
 use reexecute::{reexecute_transactions_with_blockifier, ProverPerContractStorage};
-use rpc_client::pathfinder::proofs::{PathfinderClassProof, ProofVerificationError};
+use rpc_client::pathfinder::proofs::{PathfinderClassProof, PathfinderProof, ProofVerificationError};
 use rpc_client::RpcClient;
 use rpc_replay::block_context::build_block_context;
 use rpc_replay::rpc_state_reader::AsyncRpcStateReader;
@@ -120,7 +120,7 @@ pub async fn prove_block(
     full_output: bool,
 ) -> Result<(CairoPie, StarknetOsOutput), ProveBlockError> {
     let block_id = BlockId::Number(block_number);
-    let previous_block_id = BlockId::Number(block_number - 1);
+    let previous_block_id = if block_number == 0 { None } else { Some(BlockId::Number(block_number - 1)) };
 
     let rpc_client = RpcClient::new(rpc_provider);
 
@@ -138,11 +138,15 @@ pub async fn prove_block(
     let starknet_version = get_starknet_version(&block_with_txs);
     log::debug!("Starknet version: {:?}", starknet_version);
 
-    let previous_block = match rpc_client.starknet_rpc().get_block_with_tx_hashes(previous_block_id).await? {
-        MaybePendingBlockWithTxHashes::Block(block_with_txs) => block_with_txs,
-        MaybePendingBlockWithTxHashes::PendingBlock(_) => {
-            panic!("Block is still pending!");
+    let previous_block_hash = if let Some(id) = previous_block_id {
+        match rpc_client.starknet_rpc().get_block_with_tx_hashes(id).await? {
+            MaybePendingBlockWithTxHashes::Block(block_with_txs) => block_with_txs.block_hash,
+            MaybePendingBlockWithTxHashes::PendingBlock(_) => {
+                panic!("Block is still pending!");
+            }
         }
+    } else {
+        Felt::ZERO
     };
 
     // We only need to get the older block number and hash. No need to fetch all the txs
@@ -170,7 +174,7 @@ pub async fn prove_block(
 
     let class_hash_to_compiled_class_hash = processed_state_update.class_hash_to_compiled_class_hash;
 
-    let blockifier_state_reader = AsyncRpcStateReader::new(rpc_client.clone(), BlockId::Number(block_number - 1));
+    let blockifier_state_reader = AsyncRpcStateReader::new(rpc_client.clone(), previous_block_id);
 
     let mut blockifier_state = CachedState::new(blockifier_state_reader);
 
@@ -189,10 +193,13 @@ pub async fn prove_block(
         .await
         .expect("Failed to fetch storage proofs");
 
-    let previous_storage_proofs =
+    let previous_storage_proofs = if previous_block_id.is_some() {
         get_storage_proofs(&rpc_client, block_number - 1, &tx_execution_infos, old_block_number)
             .await
-            .expect("Failed to fetch storage proofs");
+            .expect("Failed to fetch storage proofs")
+    } else {
+        HashMap::default()
+    };
 
     let default_general_config = StarknetGeneralConfig::default();
 
@@ -211,8 +218,9 @@ pub async fn prove_block(
 
     // TODO: remove this clone()
     for (contract_address, storage_proof) in storage_proofs.clone() {
+        let default_previous_storage_proof = PathfinderProof::default();
         let previous_storage_proof =
-            previous_storage_proofs.get(&contract_address).expect("failed to find previous storage proof");
+            previous_storage_proofs.get(&contract_address).unwrap_or(&default_previous_storage_proof);
         let contract_storage_root = previous_storage_proof
             .contract_data
             .as_ref()
@@ -240,15 +248,15 @@ pub async fn prove_block(
 
         let (previous_class_hash, previous_nonce) = if [Felt252::ZERO, Felt252::ONE].contains(&contract_address) {
             (Felt252::ZERO, Felt252::ZERO)
-        } else {
+        } else if let Some(prev_block_id) = previous_block_id {
             let previous_class_hash =
-                match rpc_client.starknet_rpc().get_class_hash_at(previous_block_id, contract_address).await {
+                match rpc_client.starknet_rpc().get_class_hash_at(prev_block_id, contract_address).await {
                     Ok(class_hash) => Ok(class_hash),
                     Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt252::ZERO),
                     Err(e) => Err(e),
                 }?;
 
-            let previous_nonce = match rpc_client.starknet_rpc().get_nonce(previous_block_id, contract_address).await {
+            let previous_nonce = match rpc_client.starknet_rpc().get_nonce(prev_block_id, contract_address).await {
                 Ok(nonce) => Ok(nonce),
                 Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt252::ZERO),
                 Err(e) => Err(e),
@@ -258,6 +266,8 @@ pub async fn prove_block(
             contract_address_to_class_hash.insert(contract_address, class_hash);
 
             (previous_class_hash, previous_nonce)
+        } else {
+            (Felt::ZERO, Felt::ZERO)
         };
 
         let contract_state = ContractState {
@@ -283,9 +293,14 @@ pub async fn prove_block(
     //       block, likely for contracts that are deployed in this block
     let class_proofs =
         get_class_proofs(&rpc_client, block_number, &class_hashes[..]).await.expect("Failed to fetch class proofs");
-    let previous_class_proofs = get_class_proofs(&rpc_client, block_number - 1, &class_hashes[..])
-        .await
-        .expect("Failed to fetch previous class proofs");
+
+    let previous_class_proofs = if previous_block_id.is_some() {
+        get_class_proofs(&rpc_client, block_number - 1, &class_hashes[..])
+            .await
+            .expect("Failed to fetch previous class proofs")
+    } else {
+        HashMap::default()
+    };
 
     let visited_pcs: HashMap<Felt252, Vec<Felt252>> = blockifier_state
         .visited_pcs
@@ -296,15 +311,16 @@ pub async fn prove_block(
         .collect();
 
     // we're assuming there's always at least one storage proof in the list
-    let (.., prev_proofs) = previous_storage_proofs.iter().next().expect("there should be at least one storage proof");
+    let default_previous_storage_proof = (&Felt::ZERO, &PathfinderProof::default());
+    let (.., prev_proofs) = previous_storage_proofs.iter().next().unwrap_or(default_previous_storage_proof);
     let (.., new_proofs) = storage_proofs.iter().next().expect("there should be at least one storage proof");
 
     // The root of the class commitment tree for previous and current block
     // Using requested storage proof instead of getting them from class proofs
     // If the block doesn't contain transactions, `class_proofs` will be empty
     // Pathfinder will send a None on class_commitment when the tree is not initialized, ie, root is zero
-    let previous_root = prev_proofs.class_commitment.unwrap_or(Felt::ZERO);
-    let updated_root = new_proofs.class_commitment.unwrap_or(Felt::ZERO);
+    let previous_classes_tree_root = prev_proofs.class_commitment.unwrap_or(Felt::ZERO);
+    let updated_classes_tree_root = new_proofs.class_commitment.unwrap_or(Felt::ZERO);
 
     // On devnet and until block 10, the storage_root_idx might be None and that means that contract_proof is empty
     let previous_contract_trie_root = match prev_proofs.contract_proof.first() {
@@ -332,8 +348,12 @@ pub async fn prove_block(
         commitment_facts: global_state_commitment_facts,
     };
 
-    let contract_class_commitment_info =
-        compute_class_commitment(&previous_class_proofs, &class_proofs, previous_root, updated_root);
+    let contract_class_commitment_info = compute_class_commitment(
+        &previous_class_proofs,
+        &class_proofs,
+        previous_classes_tree_root,
+        updated_classes_tree_root,
+    );
 
     let os_input = Rc::new(StarknetOsInput {
         contract_state_commitment_info,
@@ -348,9 +368,10 @@ pub async fn prove_block(
         transactions,
         declared_class_hash_to_component_hashes: declared_class_hash_component_hashes,
         new_block_hash: block_with_txs.block_hash,
-        prev_block_hash: previous_block.block_hash,
+        prev_block_hash: previous_block_hash,
         full_output,
     });
+
     let execution_helper = ExecutionHelperWrapper::<ProverPerContractStorage>::new(
         contract_storages,
         tx_execution_infos,

--- a/crates/bin/prove_block/src/reexecute.rs
+++ b/crates/bin/prove_block/src/reexecute.rs
@@ -92,7 +92,7 @@ pub fn reexecute_transactions_with_blockifier<S: StateReader>(
 
 pub(crate) struct ProverPerContractStorage {
     rpc_client: RpcClient,
-    block_id: BlockId,
+    block_id: Option<BlockId>,
     contract_address: Felt252,
     previous_tree_root: Felt252,
     storage_proof: PathfinderProof,
@@ -103,7 +103,7 @@ pub(crate) struct ProverPerContractStorage {
 impl ProverPerContractStorage {
     pub fn new(
         rpc_client: RpcClient,
-        block_id: BlockId,
+        block_id: Option<BlockId>,
         contract_address: Felt252,
         previous_tree_root: Felt252,
         storage_proof: PathfinderProof,
@@ -192,22 +192,20 @@ impl PerContractStorage for ProverPerContractStorage {
     async fn read(&mut self, key: TreeIndex) -> Option<Felt252> {
         if let Some(value) = self.ongoing_storage_changes.get(&key) {
             Some(*value)
-        } else {
+        } else if let Some(id) = self.block_id {
             let key_felt = Felt252::from(key.clone());
             // TODO: this should be fallible
-            let value = match self
-                .rpc_client
-                .starknet_rpc()
-                .get_storage_at(self.contract_address, key_felt, self.block_id)
-                .await
-            {
-                Ok(value) => Ok(value),
-                Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt252::ZERO),
-                Err(e) => Err(e),
-            }
-            .unwrap();
+            let value =
+                match self.rpc_client.starknet_rpc().get_storage_at(self.contract_address, key_felt, id).await {
+                    Ok(value) => Ok(value),
+                    Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt252::ZERO),
+                    Err(e) => Err(e),
+                }
+                .unwrap();
             self.ongoing_storage_changes.insert(key, value);
             Some(value)
+        } else {
+            Some(Felt252::ZERO)
         }
     }
 

--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -203,6 +203,7 @@ fn get_key_following_edge(key: Felt, height: Height, edge_path: &EdgePath) -> Fe
 
 fn merge_storage_proofs(proofs: Vec<PathfinderProof>) -> PathfinderProof {
     let class_commitment = proofs[0].class_commitment;
+    let contract_commitment = proofs[0].contract_commitment;
     let state_commitment = proofs[0].state_commitment;
     let contract_proof = proofs[0].contract_proof.clone();
 
@@ -222,7 +223,7 @@ fn merge_storage_proofs(proofs: Vec<PathfinderProof>) -> PathfinderProof {
         contract_data
     };
 
-    PathfinderProof { class_commitment, state_commitment, contract_proof, contract_data }
+    PathfinderProof { contract_commitment, class_commitment, state_commitment, contract_proof, contract_data }
 }
 
 pub(crate) async fn get_class_proofs(

--- a/crates/bin/prove_block/src/state_utils.rs
+++ b/crates/bin/prove_block/src/state_utils.rs
@@ -30,7 +30,7 @@ pub struct FormattedStateUpdate {
 /// - Consolidates that information into a `FormattedStateUpdate`.
 pub(crate) async fn get_formatted_state_update(
     rpc_client: &RpcClient,
-    previous_block_id: BlockId,
+    previous_block_id: Option<BlockId>,
     block_id: BlockId,
 ) -> Result<(FormattedStateUpdate, Vec<TransactionTraceWithHash>), ProveBlockError> {
     let state_update =
@@ -166,7 +166,7 @@ fn add_compiled_class_to_os_input(
 /// the `class_hash_to_compiled_class_hash` map is updated with new entries.
 async fn build_compiled_class_and_maybe_update_class_hash_to_compiled_class_hash(
     provider: &RpcClient,
-    previous_block_id: BlockId,
+    previous_block_id: Option<BlockId>,
     block_id: BlockId,
     accessed_addresses: &HashSet<Felt252>,
     declared_classes: &HashSet<Felt252>,
@@ -184,28 +184,29 @@ async fn build_compiled_class_and_maybe_update_class_hash_to_compiled_class_hash
     let mut deprecated_compiled_contract_classes: HashMap<Felt252, GenericDeprecatedCompiledClass> = HashMap::new();
 
     for contract_address in accessed_addresses {
-        // In case there is a class change, we need to get the compiled class for
-        // the block to prove and for the previous block as they may differ.
-        // Note that we must also consider the case where the contract was deployed in the current
-        // block, so we can ignore "ContractNotFound" failures.
-        if let Err(e) = add_compiled_class_from_contract_to_os_input(
-            provider,
-            *contract_address,
-            previous_block_id,
-            class_hash_to_compiled_class_hash,
-            &mut compiled_contract_classes,
-            &mut deprecated_compiled_contract_classes,
-        )
-        .await
-        {
-            match e {
-                ProveBlockError::RpcError(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
-                    // The contract was deployed in the current block, nothing to worry about
+        if let Some(prev_id) = previous_block_id {
+            // In case there is a class change, we need to get the compiled class for
+            // the block to prove and for the previous block as they may differ.
+            // Note that we must also consider the case where the contract was deployed in the current
+            // block, so we can ignore "ContractNotFound" failures.
+            if let Err(e) = add_compiled_class_from_contract_to_os_input(
+                provider,
+                *contract_address,
+                prev_id,
+                class_hash_to_compiled_class_hash,
+                &mut compiled_contract_classes,
+                &mut deprecated_compiled_contract_classes,
+            )
+            .await
+            {
+                match e {
+                    ProveBlockError::RpcError(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
+                        // The contract was deployed in the current block, nothing to worry about
+                    }
+                    _ => return Err(e),
                 }
-                _ => return Err(e),
             }
         }
-
         add_compiled_class_from_contract_to_os_input(
             provider,
             *contract_address,

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -13,4 +13,5 @@ serde_json = { workspace = true }
 starknet = { workspace = true }
 starknet-os = { workspace = true }
 starknet-types-core = { workspace = true }
+starknet-crypto = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod client;
 pub mod pathfinder;
+pub(crate) mod types;
 
 pub use client::RpcClient;

--- a/crates/rpc-client/src/pathfinder/client.rs
+++ b/crates/rpc-client/src/pathfinder/client.rs
@@ -1,10 +1,14 @@
+use std::collections::VecDeque;
+
 use reqwest::{Response, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::json;
+use starknet::macros::short_string;
 use starknet_types_core::felt::Felt;
 
-use crate::pathfinder::proofs::{PathfinderClassProof, PathfinderProof};
+use crate::pathfinder::proofs::{ContractData, PathfinderClassProof, PathfinderProof, TrieNode};
+use crate::types::{GetStorageProofResponse, MerkleNode, NodeWithHash};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
@@ -30,7 +34,7 @@ async fn post_jsonrpc_request<T: DeserializeOwned>(
     params: serde_json::Value,
 ) -> Result<T, ClientError> {
     let request = jsonrpc_request(method, params);
-    let response = client.post(format!("{}/rpc/pathfinder/v0.1", rpc_provider)).json(&request).send().await?;
+    let response = client.post(format!("{}", rpc_provider)).json(&request).send().await?;
 
     #[derive(Deserialize)]
     struct TransactionReceiptResponse<T> {
@@ -61,7 +65,7 @@ pub struct PathfinderRpcClient {
 
 impl PathfinderRpcClient {
     pub fn new(base_url: &str) -> Self {
-        let starknet_rpc_url = format!("{}/rpc/v0_7", base_url);
+        let starknet_rpc_url = format!("{}", base_url);
         log::info!("Starknet RPC URL: {}", starknet_rpc_url);
         let http_client =
             reqwest::ClientBuilder::new().build().unwrap_or_else(|e| panic!("Could not build reqwest client: {e}"));
@@ -75,13 +79,62 @@ impl PathfinderRpcClient {
         contract_address: Felt,
         keys: &[Felt],
     ) -> Result<PathfinderProof, ClientError> {
-        post_jsonrpc_request(
+        let mut proofs = VecDeque::new();
+
+        if keys.is_empty() {
+            let proof = self.get_proof_one_key(block_number, contract_address, None).await?;
+            proofs.push_back(proof);
+        } else {
+            for key in keys {
+                let proof = self.get_proof_one_key(block_number, contract_address, Some(*key)).await?;
+                proofs.push_back(proof);
+            }
+        }
+
+        // Merge all the proofs into a single proof
+        let mut proof = proofs.pop_front().expect("must have at least one");
+        let contract_data = proof.contract_data.as_mut().expect("must have contract data");
+
+        for proof in proofs {
+            contract_data.storage_proofs.push(proof.contract_data.unwrap().storage_proofs[0].clone());
+        }
+
+        Ok(proof)
+    }
+
+    async fn get_proof_one_key(
+        &self,
+        block_number: u64,
+        contract_address: Felt,
+        key: Option<Felt>,
+    ) -> Result<PathfinderProof, ClientError> {
+        let key = if let Some(key) = key { vec![key] } else { Vec::new() };
+
+        let json = json!({
+            "block_id": { "block_number": block_number },
+            "contract_addresses": [contract_address],
+            "contracts_storage_keys": [{
+                "contract_address": contract_address,
+                "storage_keys": key
+            }]
+        });
+
+        log::debug!(
+            "querying starknet_getStorageProof for address {:x} key {:?} at block {:x}:\n {}",
+            contract_address,
+            key,
+            block_number,
+            json
+        );
+        let response = post_jsonrpc_request::<GetStorageProofResponse>(
             &self.http_client,
             &self.rpc_base_url,
-            "pathfinder_getProof",
-            json!({ "block_id": { "block_number": block_number }, "contract_address": contract_address, "keys": keys }),
+            "starknet_getStorageProof",
+            json,
         )
-        .await
+        .await?;
+
+        Ok(katana_to_pathfinder_proof(response))
     }
 
     pub async fn get_class_proof(
@@ -89,13 +142,74 @@ impl PathfinderRpcClient {
         block_number: u64,
         class_hash: &Felt,
     ) -> Result<PathfinderClassProof, ClientError> {
-        log::debug!("querying pathfinder_getClassProof for {:x}", class_hash);
-        post_jsonrpc_request(
+        log::debug!("querying starknet_getStorageProofs for class {:x} at block {:x}", class_hash, block_number);
+
+        let response = post_jsonrpc_request::<GetStorageProofResponse>(
             &self.http_client,
             &self.rpc_base_url,
-            "pathfinder_getClassProof",
-            json!({ "block_id": { "block_number": block_number }, "class_hash": class_hash }),
+            "starknet_getStorageProof",
+            json!({ "block_id": { "block_number": block_number }, "class_hashes": [class_hash] }),
         )
-        .await
+        .await?;
+
+        Ok(katana_to_pathfinder_class_proof(response))
+    }
+}
+
+// - this conversion function assumes that the proof is associated with only a single contract's storage key
+// - everytime we fetch a storage proof, we should also request the contract proof.
+pub(crate) fn katana_to_pathfinder_proof(proof: GetStorageProofResponse) -> PathfinderProof {
+    let contract_proof = proof.contracts_proof;
+    let contract_leaf = contract_proof.contract_leaves_data.first().expect("must have exactly one");
+    let storage_proofs = proof.contracts_storage_proofs.nodes.first().expect("must have exactly one");
+
+    let state_commitment = starknet_crypto::poseidon_hash_many(&[
+        short_string!("STARKNET_STATE_V0"),
+        proof.global_roots.contracts_tree_root,
+        proof.global_roots.classes_tree_root,
+    ]);
+
+    // convert storage proofs to pathfinder types
+    let mut pf_storage_proofs = Vec::with_capacity(1);
+    let mut pf_storage_proof: Vec<TrieNode> = Vec::with_capacity(pf_storage_proofs.len());
+
+    for n in &storage_proofs.0 {
+        let NodeWithHash { node, .. } = n;
+        pf_storage_proof.push(node.clone().into());
+    }
+
+    pf_storage_proofs.push(pf_storage_proof);
+
+    // convert contract proofs to pathfinder types
+    let mut pf_contract_proof: Vec<TrieNode> = Vec::with_capacity(contract_proof.nodes.len());
+    for n in &contract_proof.nodes.0 {
+        let NodeWithHash { node, .. } = n;
+        pf_contract_proof.push(node.clone().into());
+    }
+
+    PathfinderProof {
+        state_commitment: Some(state_commitment),
+        contract_commitment: proof.global_roots.contracts_tree_root,
+        class_commitment: Some(proof.global_roots.classes_tree_root),
+        contract_proof: pf_contract_proof,
+        contract_data: Some(ContractData { root: contract_leaf.storage_root, storage_proofs: pf_storage_proofs }),
+    }
+}
+
+pub(crate) fn katana_to_pathfinder_class_proof(proof: GetStorageProofResponse) -> PathfinderClassProof {
+    let class_proof = proof.classes_proof.nodes.iter().map(|node| TrieNode::from(node.node.clone())).collect();
+    let class_commitment = proof.global_roots.classes_tree_root;
+    PathfinderClassProof { class_commitment, class_proof }
+}
+
+impl From<MerkleNode> for TrieNode {
+    fn from(node: MerkleNode) -> Self {
+        match node {
+            MerkleNode::Edge { path, length, child } => super::proofs::TrieNode::Edge {
+                path: super::proofs::EdgePath { value: path, len: length as u64 },
+                child,
+            },
+            MerkleNode::Binary { left, right } => super::proofs::TrieNode::Binary { left, right },
+        }
     }
 }

--- a/crates/rpc-client/src/pathfinder/client.rs
+++ b/crates/rpc-client/src/pathfinder/client.rs
@@ -34,7 +34,7 @@ async fn post_jsonrpc_request<T: DeserializeOwned>(
     params: serde_json::Value,
 ) -> Result<T, ClientError> {
     let request = jsonrpc_request(method, params);
-    let response = client.post(format!("{}", rpc_provider)).json(&request).send().await?;
+    let response = client.post(rpc_provider.to_string()).json(&request).send().await?;
 
     #[derive(Deserialize)]
     struct TransactionReceiptResponse<T> {
@@ -65,7 +65,7 @@ pub struct PathfinderRpcClient {
 
 impl PathfinderRpcClient {
     pub fn new(base_url: &str) -> Self {
-        let starknet_rpc_url = format!("{}", base_url);
+        let starknet_rpc_url = base_url.to_string();
         log::info!("Starknet RPC URL: {}", starknet_rpc_url);
         let http_client =
             reqwest::ClientBuilder::new().build().unwrap_or_else(|e| panic!("Could not build reqwest client: {e}"));

--- a/crates/rpc-client/src/pathfinder/proofs.rs
+++ b/crates/rpc-client/src/pathfinder/proofs.rs
@@ -76,6 +76,7 @@ impl ContractData {
 #[derive(Debug, Clone, Deserialize)]
 pub struct PathfinderProof {
     pub state_commitment: Option<Felt>,
+    pub contract_commitment: Felt,
     pub class_commitment: Option<Felt>,
     pub contract_proof: Vec<TrieNode>,
     pub contract_data: Option<ContractData>,

--- a/crates/rpc-client/src/pathfinder/proofs.rs
+++ b/crates/rpc-client/src/pathfinder/proofs.rs
@@ -73,7 +73,7 @@ impl ContractData {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct PathfinderProof {
     pub state_commitment: Option<Felt>,
     pub contract_commitment: Felt,

--- a/crates/rpc-client/src/types.rs
+++ b/crates/rpc-client/src/types.rs
@@ -1,0 +1,114 @@
+//! Copied from `katana-rpc-types` to avoid dependency on `katana-rpc-types` (makes it difficult to manage dependencies)
+
+use std::ops::{Deref, DerefMut};
+
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContractStorageKeys {
+    #[serde(rename = "contract_address")]
+    pub address: Felt,
+    #[serde(rename = "storage_keys")]
+    pub keys: Vec<Felt>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GlobalRoots {
+    /// The associated block hash (needed in case the caller used a block tag for the block_id
+    /// parameter).
+    pub block_hash: Felt,
+    pub classes_tree_root: Felt,
+    pub contracts_tree_root: Felt,
+}
+
+/// Node in the Merkle-Patricia trie.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MerkleNode {
+    /// Represents a path to the highest non-zero descendant node.
+    Edge {
+        /// An integer whose binary representation represents the path from the current node to its
+        /// highest non-zero descendant (bounded by 2^251)
+        path: Felt,
+        /// The length of the path (bounded by 251).
+        length: u8,
+        /// The hash of the unique non-zero maximal-height descendant node.
+        child: Felt,
+    },
+
+    /// An internal node whose both children are non-zero.
+    Binary {
+        /// The hash of the left child.
+        left: Felt,
+        /// The hash of the right child.
+        right: Felt,
+    },
+}
+
+/// The response type for `starknet_getStorageProof` method.
+///
+/// The requested storage proofs. Note that if a requested leaf has the default value, the path to
+/// it may end in an edge node whose path is not a prefix of the requested leaf, thus effectively
+/// proving non-membership
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetStorageProofResponse {
+    pub global_roots: GlobalRoots,
+    pub classes_proof: ClassesProof,
+    pub contracts_proof: ContractsProof,
+    pub contracts_storage_proofs: ContractStorageProofs,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ClassesProof {
+    pub nodes: Nodes,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ContractsProof {
+    /// The nodes in the union of the paths from the contracts tree root to the requested leaves.
+    pub nodes: Nodes,
+    /// The nonce and class hash for each requested contract address, in the order in which they
+    /// appear in the request. These values are needed to construct the associated leaf node.
+    pub contract_leaves_data: Vec<ContractLeafData>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ContractLeafData {
+    // NOTE: This field is not specified in the RPC specs, but the contract storage root is
+    // required to compute the contract state hash (ie the value of the contracts trie). We
+    // include this in the response for now to ease the conversions over on SNOS side.
+    pub storage_root: Felt,
+    pub nonce: Felt,
+    pub class_hash: Felt,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ContractStorageProofs {
+    pub nodes: Vec<Nodes>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NodeWithHash {
+    pub node_hash: Felt,
+    pub node: MerkleNode,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Nodes(pub Vec<NodeWithHash>);
+
+impl Deref for Nodes {
+    type Target = Vec<NodeWithHash>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Nodes {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/crates/rpc-replay/src/block_context.rs
+++ b/crates/rpc-replay/src/block_context.rs
@@ -51,15 +51,22 @@ pub fn build_block_context(
 
     let chain_info = ChainInfo {
         chain_id,
-        // cf. https://docs.starknet.io/tools/important-addresses/
         fee_token_addresses: FeeTokenAddresses {
             strk_fee_token_address: contract_address!(
-                "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+                "0x2e7442625bab778683501c0eadbc1ea17b3535da040a12ac7d281066e915eea"
             ),
             eth_fee_token_address: contract_address!(
-                "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+                "0x2e7442625bab778683501c0eadbc1ea17b3535da040a12ac7d281066e915eea"
             ),
-        },
+        }, /* cf. https://docs.starknet.io/tools/important-addresses/
+            * fee_token_addresses: FeeTokenAddresses {
+            *     strk_fee_token_address: contract_address!(
+            *         "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+            *     ),
+            *     eth_fee_token_address: contract_address!(
+            *         "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+            *     ),
+            * }, */
     };
 
     // @kariy: We use the latest versioned constants to match what Katana is using.

--- a/crates/rpc-replay/src/block_context.rs
+++ b/crates/rpc-replay/src/block_context.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU128;
 use blockifier::blockifier::block::{BlockInfo, GasPrices};
 use blockifier::bouncer::BouncerConfig;
 use blockifier::context::{BlockContext, ChainInfo, FeeTokenAddresses};
-use blockifier::versioned_constants::VersionedConstants;
+use blockifier::versioned_constants::{StarknetVersion, VersionedConstants};
 use starknet::core::types::{BlockWithTxs, Felt, L1DataAvailabilityMode};
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use starknet_api::core::{ChainId, ContractAddress, PatriciaKey};
@@ -69,8 +69,11 @@ pub fn build_block_context(
             * }, */
     };
 
-    // @kariy: We use the latest versioned constants to match what Katana is using.
-    let versioned_constants = VersionedConstants::latest_constants();
+    // IMPORTANT:
+    // The versioned constant must match the version that the block was executed with.
+    // In this case, the versioned constant that Katana is using.
+    const SN_VERSION: StarknetVersion = StarknetVersion::Latest; // v0.13.3
+    let versioned_constants = VersionedConstants::get(SN_VERSION);
     let bouncer_config = BouncerConfig::max();
 
     Ok(BlockContext::new(block_info, chain_info, versioned_constants.clone(), bouncer_config))

--- a/crates/rpc-replay/src/block_context.rs
+++ b/crates/rpc-replay/src/block_context.rs
@@ -27,7 +27,7 @@ fn felt_to_gas_price(price: &Felt) -> Result<NonZeroU128, FeltConversionError> {
 pub fn build_block_context(
     chain_id: ChainId,
     block: &BlockWithTxs,
-    starknet_version: blockifier::versioned_constants::StarknetVersion,
+    _: blockifier::versioned_constants::StarknetVersion,
 ) -> Result<BlockContext, FeltConversionError> {
     let sequencer_address_hex = block.sequencer_address.to_hex_string();
     let sequencer_address = contract_address!(sequencer_address_hex.as_str());
@@ -62,7 +62,8 @@ pub fn build_block_context(
         },
     };
 
-    let versioned_constants = VersionedConstants::get(starknet_version);
+    // @kariy: We use the latest versioned constants to match what Katana is using.
+    let versioned_constants = VersionedConstants::latest_constants();
     let bouncer_config = BouncerConfig::max();
 
     Ok(BlockContext::new(block_info, chain_info, versioned_constants.clone(), bouncer_config))

--- a/crates/rpc-replay/src/rpc_state_reader.rs
+++ b/crates/rpc-replay/src/rpc_state_reader.rs
@@ -14,11 +14,11 @@ use crate::utils::execute_coroutine;
 
 pub struct AsyncRpcStateReader {
     rpc_client: RpcClient,
-    block_id: BlockId,
+    block_id: Option<BlockId>,
 }
 
 impl AsyncRpcStateReader {
-    pub fn new(rpc_client: RpcClient, block_id: BlockId) -> Self {
+    pub fn new(rpc_client: RpcClient, block_id: Option<BlockId>) -> Self {
         Self { rpc_client, block_id }
     }
 }
@@ -33,90 +33,103 @@ fn to_state_err<E: ToString>(e: E) -> StateError {
 
 impl AsyncRpcStateReader {
     pub async fn get_storage_at_async(&self, contract_address: ContractAddress, key: StorageKey) -> StateResult<Felt> {
-        let storage_value = match self
-            .rpc_client
-            .starknet_rpc()
-            .get_storage_at(*contract_address.key(), *key.0.key(), self.block_id)
-            .await
-        {
-            Ok(value) => Ok(value),
-            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
-            Err(e) => Err(provider_error_to_state_error(e)),
-        }?;
+        if let Some(id) = self.block_id {
+            let storage_value =
+                match self.rpc_client.starknet_rpc().get_storage_at(*contract_address.key(), *key.0.key(), id).await {
+                    Ok(value) => Ok(value),
+                    Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
+                    Err(e) => Err(provider_error_to_state_error(e)),
+                }?;
 
-        Ok(storage_value)
+            Ok(storage_value)
+        } else {
+            Ok(Felt::ZERO)
+        }
     }
 
     pub async fn get_nonce_at_async(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        let res = self.rpc_client.starknet_rpc().get_nonce(self.block_id, *contract_address.key()).await;
-        let nonce = match res {
-            Ok(value) => Ok(value),
-            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
-            Err(e) => Err(provider_error_to_state_error(e)),
-        }?;
-        Ok(Nonce(nonce))
+        if let Some(id) = self.block_id {
+            let res = self.rpc_client.starknet_rpc().get_nonce(id, *contract_address.key()).await;
+            let nonce = match res {
+                Ok(value) => Ok(value),
+                Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
+                Err(e) => Err(provider_error_to_state_error(e)),
+            }?;
+            Ok(Nonce(nonce))
+        } else {
+            Ok(Nonce(Felt::ZERO))
+        }
     }
 
     pub async fn get_class_hash_at_async(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        let class_hash =
-            match self.rpc_client.starknet_rpc().get_class_hash_at(self.block_id, *contract_address.key()).await {
+        if let Some(id) = self.block_id {
+            let class_hash = match self.rpc_client.starknet_rpc().get_class_hash_at(id, *contract_address.key()).await {
                 Ok(class_hash) => Ok(class_hash),
                 Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(ClassHash::default().0),
                 Err(e) => Err(provider_error_to_state_error(e)),
             }?;
 
-        Ok(ClassHash(class_hash))
+            Ok(ClassHash(class_hash))
+        } else {
+            Ok(ClassHash::default())
+        }
     }
 
     pub async fn get_compiled_contract_class_async(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
-        let contract_class = match self.rpc_client.starknet_rpc().get_class(self.block_id, class_hash.0).await {
-            Ok(contract_class) => Ok(contract_class),
-            // If the ContractClass is declared in the current block,
-            // might trigger this error when trying to get it on the previous block.
-            // Returning a `UndeclaredClassHash` allows blockifier to continue execution
-            // Reference: https://github.com/starkware-libs/sequencer/blob/1ade15c645882e3a0bd70ef8f79b23fc66a517e0/crates/blockifier/src/state/cached_state.rs#L178-L200
-            Err(ProviderError::StarknetError(StarknetError::ClassHashNotFound)) => {
-                Err(StateError::UndeclaredClassHash(ClassHash(class_hash.0)))
-            }
-            Err(e) => Err(provider_error_to_state_error(e)),
-        }?;
+        if let Some(id) = self.block_id {
+            let contract_class = match self.rpc_client.starknet_rpc().get_class(id, class_hash.0).await {
+                Ok(contract_class) => Ok(contract_class),
+                Err(ProviderError::StarknetError(StarknetError::ClassHashNotFound)) => {
+                    Err(StateError::UndeclaredClassHash(ClassHash(class_hash.0)))
+                }
+                Err(e) => Err(provider_error_to_state_error(e)),
+            }?;
 
-        let contract_class: ContractClass = match contract_class {
-            starknet::core::types::ContractClass::Sierra(sierra_class) => {
-                let contract_class = GenericSierraContractClass::from(sierra_class);
-                let compiled_class = contract_class.compile().map_err(to_state_err)?;
-                compiled_class.to_blockifier_contract_class().map(Into::into).map_err(to_state_err)?
-            }
-            starknet::core::types::ContractClass::Legacy(legacy_class) => {
-                let contract_class = GenericDeprecatedCompiledClass::try_from(legacy_class).map_err(to_state_err)?;
-                contract_class.to_blockifier_contract_class().map(Into::into).map_err(to_state_err)?
-            }
-        };
+            let contract_class: ContractClass = match contract_class {
+                starknet::core::types::ContractClass::Sierra(sierra_class) => {
+                    let contract_class = GenericSierraContractClass::from(sierra_class);
+                    let compiled_class = contract_class.compile().map_err(to_state_err)?;
+                    compiled_class.to_blockifier_contract_class().map(Into::into).map_err(to_state_err)?
+                }
+                starknet::core::types::ContractClass::Legacy(legacy_class) => {
+                    let contract_class =
+                        GenericDeprecatedCompiledClass::try_from(legacy_class).map_err(to_state_err)?;
+                    contract_class.to_blockifier_contract_class().map(Into::into).map_err(to_state_err)?
+                }
+            };
 
-        Ok(contract_class)
+            Ok(contract_class)
+        } else {
+            Err(StateError::UndeclaredClassHash(class_hash))
+        }
     }
 
     pub async fn get_compiled_class_hash_async(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
-        let contract_class = self
-            .rpc_client
-            .starknet_rpc()
-            .get_class(self.block_id, class_hash.0)
-            .await
-            .map_err(provider_error_to_state_error)?;
+        if let Some(id) = self.block_id {
+            let contract_class = self
+                .rpc_client
+                .starknet_rpc()
+                .get_class(id, class_hash.0)
+                .await
+                .map_err(provider_error_to_state_error)?;
 
-        let class_hash: GenericClassHash = match contract_class {
-            starknet::core::types::ContractClass::Sierra(sierra_class) => {
-                let contract_class = GenericSierraContractClass::from(sierra_class);
-                let compiled_class = contract_class.compile().map_err(to_state_err)?;
-                compiled_class.class_hash().map_err(to_state_err)?
-            }
-            starknet::core::types::ContractClass::Legacy(legacy_class) => {
-                let contract_class = GenericDeprecatedCompiledClass::try_from(legacy_class).map_err(to_state_err)?;
-                contract_class.class_hash().map_err(to_state_err)?
-            }
-        };
+            let class_hash: GenericClassHash = match contract_class {
+                starknet::core::types::ContractClass::Sierra(sierra_class) => {
+                    let contract_class = GenericSierraContractClass::from(sierra_class);
+                    let compiled_class = contract_class.compile().map_err(to_state_err)?;
+                    compiled_class.class_hash().map_err(to_state_err)?
+                }
+                starknet::core::types::ContractClass::Legacy(legacy_class) => {
+                    let contract_class =
+                        GenericDeprecatedCompiledClass::try_from(legacy_class).map_err(to_state_err)?;
+                    contract_class.class_hash().map_err(to_state_err)?
+                }
+            };
 
-        Ok(class_hash.into())
+            Ok(class_hash.into())
+        } else {
+            Err(StateError::UndeclaredClassHash(class_hash))
+        }
     }
 }
 

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -7,10 +7,10 @@ use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::errors::TransactionExecutionError;
 use rpc_client::RpcClient;
 use starknet::core::types::{
-    BlockId, DeclareTransaction, DeclareTransactionV1, DeclareTransactionV2, DeclareTransactionV3,
-    DeployAccountTransaction, DeployAccountTransactionV1, DeployAccountTransactionV3, Felt, InvokeTransaction,
-    InvokeTransactionV1, InvokeTransactionV3, L1HandlerTransaction, ResourceBoundsMapping, Transaction,
-    TransactionTrace, TransactionTraceWithHash,
+    BlockId, DeclareTransaction, DeclareTransactionV0, DeclareTransactionV1, DeclareTransactionV2,
+    DeclareTransactionV3, DeployAccountTransaction, DeployAccountTransactionV1, DeployAccountTransactionV3, Felt,
+    InvokeTransaction, InvokeTransactionV1, InvokeTransactionV3, L1HandlerTransaction, ResourceBoundsMapping,
+    Transaction, TransactionTrace, TransactionTraceWithHash,
 };
 use starknet::providers::{Provider, ProviderError};
 use starknet_api::core::{calculate_contract_address, ContractAddress, PatriciaKey};
@@ -146,6 +146,27 @@ async fn create_class_info(
     };
 
     Ok(ClassInfo::new(&blockifier_contract_class, program_length, abi_length)?)
+}
+
+async fn declare_v0_to_blockifier(
+    tx: &DeclareTransactionV0,
+    client: &RpcClient,
+    block_number: u64,
+) -> Result<blockifier::transaction::transaction_execution::Transaction, ToBlockifierError> {
+    let tx_hash = TransactionHash(tx.transaction_hash);
+    let api_tx = starknet_api::transaction::DeclareTransaction::V0(starknet_api::transaction::DeclareTransactionV0V1 {
+        max_fee: starknet_api::transaction::Fee(felt_to_u128(&tx.max_fee)?),
+        signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+        nonce: starknet_api::core::Nonce::default(),
+        class_hash: starknet_api::core::ClassHash(tx.class_hash),
+        sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address)?),
+    });
+    let class_info = create_class_info(tx.class_hash, client, block_number).await?;
+    let declare = blockifier::transaction::transactions::DeclareTransaction::new(api_tx, tx_hash, class_info)?;
+
+    Ok(blockifier::transaction::transaction_execution::Transaction::AccountTransaction(AccountTransaction::Declare(
+        declare,
+    )))
 }
 
 async fn declare_v1_to_blockifier(
@@ -365,7 +386,7 @@ pub async fn starknet_rs_to_blockifier(
             InvokeTransaction::V3(tx) => invoke_v3_to_blockifier(tx)?,
         },
         Transaction::Declare(tx) => match tx {
-            DeclareTransaction::V0(_) => unimplemented!("starknet_rs_to_blockifier with DeclareTransaction::V0"),
+            DeclareTransaction::V0(tx) => declare_v0_to_blockifier(tx, client, block_number).await?,
             DeclareTransaction::V1(tx) => declare_v1_to_blockifier(tx, client, block_number).await?,
             DeclareTransaction::V2(tx) => declare_v2_to_blockifier(tx, client, block_number).await?,
             DeclareTransaction::V3(tx) => declare_v3_to_blockifier(tx, client, block_number).await?,

--- a/crates/rpc-replay/tests/test_replay_block.rs
+++ b/crates/rpc-replay/tests/test_replay_block.rs
@@ -25,7 +25,7 @@ async fn test_replay_block() {
     let rpc_client = RpcClient::new(rpc_provider);
     let previous_block_number = block_with_txs.block_number - 1;
     let previous_block_id = BlockId::Number(previous_block_number);
-    let state_reader = AsyncRpcStateReader::new(rpc_client.clone(), previous_block_id);
+    let state_reader = AsyncRpcStateReader::new(rpc_client.clone(), Some(previous_block_id));
     let mut state = CachedState::from(state_reader);
 
     let block_context = build_block_context(ChainId::Sepolia, &block_with_txs, StarknetVersion::V0_13_1)

--- a/crates/starknet-os-types/src/class_hash_utils.rs
+++ b/crates/starknet-os-types/src/class_hash_utils.rs
@@ -1,15 +1,15 @@
 use starknet_core::types::SierraEntryPoint;
 use starknet_core::utils::starknet_keccak;
-use starknet_crypto::{poseidon_hash_many, FieldElement};
+use starknet_crypto::poseidon_hash_many;
 use starknet_types_core::felt::Felt;
 
 const CLASS_VERSION_PREFIX: &str = "CONTRACT_CLASS_V";
 
 /// A convenience function that computes a Poseidon hash over Felts rather than starknet-crypto
-/// FieldElement types. There is no `From` implementation between these types so this function
+/// Felt types. There is no `From` implementation between these types so this function
 /// masks some ugly byte mashing.
 fn poseidon_hash_many_felts<FeltIter: Iterator<Item = Felt>>(felts: FeltIter) -> Felt {
-    let field_elements: Vec<_> = felts.map(|x| FieldElement::from_bytes_be(&x.to_bytes_be()).unwrap()).collect();
+    let field_elements: Vec<_> = felts.map(|x| Felt::from_bytes_be(&x.to_bytes_be())).collect();
     let hash = poseidon_hash_many(&field_elements);
 
     Felt::from_bytes_be(&hash.to_bytes_be())

--- a/crates/starknet-os/Cargo.toml
+++ b/crates/starknet-os/Cargo.toml
@@ -43,6 +43,7 @@ serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 starknet_api = { workspace = true }
 starknet-crypto = { workspace = true }
+starknet-types-core = { workspace = true }
 starknet-os-types = { path = "../starknet-os-types" }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/starknet-os/src/crypto/pedersen.rs
+++ b/crates/starknet-os/src/crypto/pedersen.rs
@@ -1,5 +1,6 @@
-use starknet_crypto::{pedersen_hash, FieldElement};
+use starknet_crypto::pedersen_hash;
 use starknet_os_types::hash::Hash;
+use starknet_types_core::felt::Felt;
 
 use crate::storage::storage::HashFunctionType;
 
@@ -8,8 +9,8 @@ pub struct PedersenHash;
 
 impl HashFunctionType for PedersenHash {
     fn hash(x: &[u8], y: &[u8]) -> Hash {
-        let x_felt = FieldElement::from_byte_slice_be(x).unwrap();
-        let y_felt = FieldElement::from_byte_slice_be(y).unwrap();
+        let x_felt = Felt::from_bytes_be_slice(x);
+        let y_felt = Felt::from_bytes_be_slice(y);
 
         Hash::from_bytes_be(pedersen_hash(&x_felt, &y_felt).to_bytes_be())
     }

--- a/crates/starknet-os/src/crypto/poseidon.rs
+++ b/crates/starknet-os/src/crypto/poseidon.rs
@@ -1,5 +1,5 @@
 use cairo_vm::types::errors::math_errors::MathError;
-use starknet_crypto::{poseidon_hash, poseidon_hash_many, FieldElement};
+use starknet_crypto::{poseidon_hash, poseidon_hash_many, Felt};
 use starknet_os_types::hash::Hash;
 
 use crate::storage::storage::HashFunctionType;
@@ -9,8 +9,8 @@ pub struct PoseidonHash;
 
 impl HashFunctionType for PoseidonHash {
     fn hash(x: &[u8], y: &[u8]) -> Hash {
-        let x_felt = FieldElement::from_byte_slice_be(x).unwrap();
-        let y_felt = FieldElement::from_byte_slice_be(y).unwrap();
+        let x_felt = Felt::from_bytes_be_slice(x);
+        let y_felt = Felt::from_bytes_be_slice(y);
 
         Hash::from_bytes_be(poseidon_hash(x_felt, y_felt).to_bytes_be())
     }
@@ -18,8 +18,7 @@ impl HashFunctionType for PoseidonHash {
 
 /// A wrapper around `poseidon_hash_many` that takes and returns bytes.
 pub fn poseidon_hash_many_bytes(msgs: &[&[u8]]) -> Result<Hash, MathError> {
-    let field_elements: Result<Vec<_>, _> = msgs.iter().map(|elem| FieldElement::from_byte_slice_be(elem)).collect();
-    let field_elements = field_elements.map_err(|_| MathError::ByteConversionError)?;
+    let field_elements: Vec<Felt> = msgs.iter().map(|elem| Felt::from_bytes_be_slice(elem)).collect();
     let result = poseidon_hash_many(&field_elements);
 
     Ok(Hash::from_bytes_be(result.to_bytes_be()))

--- a/crates/starknet-os/src/starknet/core/os/contract_class/compiled_class_hash_objects.rs
+++ b/crates/starknet-os/src/starknet/core/os/contract_class/compiled_class_hash_objects.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use cairo_vm::Felt252;
 use num_bigint::BigUint;
-use starknet_crypto::{poseidon_hash_many, FieldElement};
+use starknet_crypto::{poseidon_hash_many, Felt};
 use starknet_os_types::hash::Hash;
 
 use crate::execution::syscall_handler_utils::SyscallExecutionError;
@@ -92,15 +92,13 @@ impl BytecodeSegmentedNode {
         // To compute the hash we'll need the segment length and the hash from the inner structure for each
         // segment. After calling poseidon hash function, we just add 1 to the result
         for segment in &self.segments {
-            felts.push(FieldElement::from(segment.segment_length.0));
+            felts.push(Felt::from(segment.segment_length.0));
 
             let inner_hash = segment.inner_structure.hash()?;
-            felts.push(FieldElement::from_byte_slice_be(inner_hash.deref()).map_err(|_| {
-                SyscallExecutionError::InternalError("conversion from Hash to FieldElement failed".into())
-            })?);
+            felts.push(Felt::from_bytes_be_slice(inner_hash.deref()));
         }
 
-        let ret = poseidon_hash_many(&felts) + FieldElement::from(1u8);
+        let ret = poseidon_hash_many(&felts) + Felt::from(1u8);
         Ok(Hash::from_bytes_be(ret.to_bytes_be()))
     }
 }
@@ -117,16 +115,8 @@ impl BytecodeLeaf {
     }
 
     pub fn hash(&self) -> Result<Hash, SyscallExecutionError> {
-        let vec_field_elements: Result<Vec<_>, _> =
-            self.data.iter().map(|value| FieldElement::from_byte_slice_be(&value.to_bytes_be())).collect();
-
-        let hash = match vec_field_elements {
-            Ok(elements) => Hash::from_bytes_be(poseidon_hash_many(&elements).to_bytes_be()),
-            Err(_) => {
-                return Err(SyscallExecutionError::InternalError("Invalid bytecode segment leaf".into()));
-            }
-        };
-
-        Ok(hash)
+        let elements: Vec<Felt> =
+            self.data.iter().map(|value| Felt::from_bytes_be_slice(&value.to_bytes_be())).collect();
+        Ok(Hash::from_bytes_be(poseidon_hash_many(&elements).to_bytes_be()))
     }
 }

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -23,7 +23,7 @@ use starknet_api::transaction::{
     ResourceBoundsMapping, TransactionHash,
 };
 use starknet_api::{contract_address, felt, patricia_key};
-use starknet_crypto::{pedersen_hash, FieldElement};
+use starknet_crypto::{pedersen_hash, Felt};
 use starknet_os::config::{BLOCK_HASH_CONTRACT_ADDRESS, STORED_BLOCK_HASH_BUFFER};
 use starknet_os::crypto::pedersen::PedersenHash;
 use starknet_os::crypto::poseidon::poseidon_hash_many_bytes;
@@ -148,7 +148,7 @@ fn poseidon_hash_on_elements(data: &[Felt252]) -> Felt252 {
 pub fn hash(a: &Felt252, b: &Felt252) -> Felt252 {
     let a_be_bytes = a.to_bytes_be();
     let b_be_bytes = b.to_bytes_be();
-    let (x, y) = (FieldElement::from_bytes_be(&a_be_bytes).unwrap(), FieldElement::from_bytes_be(&b_be_bytes).unwrap());
+    let (x, y) = (Felt::from_bytes_be(&a_be_bytes), Felt::from_bytes_be(&b_be_bytes));
 
     let result = pedersen_hash(&x, &y);
     Felt252::from_bytes_be(&result.to_bytes_be())


### PR DESCRIPTION
Assumption(s):-
1. The rollup chain's fee token address is `0x2e7442625bab778683501c0eadbc1ea17b3535da040a12ac7d281066e915eea`
	- Currently, all chain initialized with `katana init` has the same fee token, and there's only 1 token as opposed to 2, for Starknet chains.
2. The blocks must be executed using the same `VersionedConstant`, otherwise this would result in mismatch outcome (esp in terms of fee calculation).
	- We use version constants used by Starknet `v0.13.3`, and this is matched by [`katana`](https://github.com/dojoengine/dojo/pull/2956).
